### PR TITLE
Readd proper `async`/`await` keywords to examples/CLI, add `default` case in `cli.ts`

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Import the `hash` and/or `verify` functions and use them:
 ```ts
 import { hash, verify } from "https://deno.land/x/scrypt/mod.ts";
 
-const hashResult = hash("password");
-const verifyResult = verify("password", hashResult);
+const hashResult = await hash("password");
+const verifyResult = await verify("password", hashResult);
 ```
 
 ### CLI with [DPX](https://github.com/denorg/dpx)

--- a/cli.ts
+++ b/cli.ts
@@ -8,19 +8,23 @@ if (import.meta.main) {
   switch (command) {
     case "hash":
       for (const arg of args) {
-        console.log(hash(arg));
+        console.log(await hash(arg));
       }
       break;
     case "verify":
-      console.log(verify(args[0], args[1]));
+      console.log(await verify(args[0], args[1]));
       break;
     case "salt":
       if (args.length) {
         for (const arg of args) {
-          console.log(genSalt(parseInt(arg, 10)));
+          console.log(await genSalt(parseInt(arg, 10)));
         }
       } else {
-        console.log(genSalt());
+        console.log(await genSalt());
       }
+      break;
+    default: {
+	console.log(`usage: hash <password>, verify <password>, <hash>`)
+    }
   }
 }


### PR DESCRIPTION
Regarding the `async` thing - As you have mentioned in commit [2e7997e11dd652f1dcfed0d84564ef6c76a7d2a7](https://github.com/denorg/scrypt/commit/2e7997e11dd652f1dcfed0d84564ef6c76a7d2a7), you believe that the WASM build had made the need to use `async`/`await` redundant. I want you to know, from my experience using it, that's not true.

Let's just use the example you gave out in the `README`, and break it down piece by piece...

```
pk ~ > deno
Deno 1.24.2
exit using ctrl+d or close()
> import { hash, verify } from "https://deno.land/x/scrypt/mod.ts";

undefined
> const hashResult = hash("password");

undefined
> hashResult
Promise {
"c2NyeXB0AA4AAAAIAAAAAbb0SyORv+D5hZnWGFdooht5tuoqlM4JTdIYKQPcQTlrUEYByCq20d2+2an6H3DV8+Embr96XNQULJ1X..."
}
```
Notice that it returns a `Promise`? That's a pretty big deal, because the lack of an `await` statement doesn't cause the value to be registered as properly fulfilled. Indeed, if we try to move onto the next piece...

```
> const verifyResult = verify("password", hashResult);

undefined
> verifyResult
Promise {
  <rejected> TypeError: formattedHash.substring is not a function
    at detectFormat (https://deno.land/x/scrypt@v2.1.1/lib/helpers.ts:119:25)
    at verify (https://deno.land/x/scrypt@v2.1.1/mod.ts:77:28)
    at <anonymous>:2:22
}
```
It's marked as Rejected. The code given is literally unusable.

Now, if we add the proper `await` keywords...

```
> const hashResult = await hash("password");

undefined
> hashResult
"c2NyeXB0AA4AAAAIAAAAAcn3f65D+SUQK0l83StELYsu0viUlDYJH5lH7jwYvn3d0jRCN9w7w0tvxaqCyk1YL6u6VIU5aemLUvh3ysZK0hF/AEiOwfk4RGBb4yEy2agN"
> const verifyResult = await verify("password", hashResult);

undefined
> verifyResult
true
```

It works as intended.

This issue has been addressed in both the already-described `README`, and the CLI you wrote as a demonstration of the library.

Oh, and while we're on the subject of the library - A default case was added so that any users who didn't provide a `hash` or `verify` flag would receive the following:

```
usage: hash <password>, verify <password>, <hash>
```  

I just thought that would be nice.